### PR TITLE
Avoid linting duplicate files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "version": "1.0.0",
   "scripts": {
-    "lint:all": "tsslint --vue-project ./packages/*/tsconfig.json",
+    "lint:all": "tsslint --vue-project {packages/admin/tsconfig.json,packages/{app,share}/.nuxt/tsconfig.*.json}",
     "lint:root": "tsslint --vue-project ./tsconfig.json",
     "lint:app": "tsslint --vue-project ./packages/app/tsconfig.json",
     "lint:admin": "tsslint --vue-project ./packages/admin/tsconfig.json",

--- a/packages/admin/tsslint.config.ts
+++ b/packages/admin/tsslint.config.ts
@@ -1,0 +1,6 @@
+import baseConfig from '../../tsslint.config.ts';
+
+export default {
+    ...baseConfig,
+    include: ['**'],
+};

--- a/packages/app/tsslint.config.ts
+++ b/packages/app/tsslint.config.ts
@@ -1,0 +1,6 @@
+import baseConfig from '../../tsslint.config.ts';
+
+export default {
+    ...baseConfig,
+    include: ['**'],
+};

--- a/packages/share/tsslint.config.ts
+++ b/packages/share/tsslint.config.ts
@@ -1,0 +1,6 @@
+import baseConfig from '../../tsslint.config.ts';
+
+export default {
+    ...baseConfig,
+    include: ['**'],
+};


### PR DESCRIPTION
By creating a `tsslint.config.ts` under each package and setting `include: ['**']`, you can force tsslint to only capture input files in the directory where `tsslint.config.ts` is located, avoiding duplicate linting.